### PR TITLE
feat: portable deploy, scoped credentials, local overrides

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,7 @@
 PATH=$HOME/dotfiles/bin:$PATH
 
+[[ -f $HOME/.bashrc.local ]] && source $HOME/.bashrc.local
+
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
 [ -f ~/.safe-chain/scripts/init-posix.sh ] && source ~/.safe-chain/scripts/init-posix.sh

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(git fetch:*)"
-    ],
+    "allow": ["Bash(git fetch:*)"],
     "deny": [],
     "ask": []
   }

--- a/.gitconfig
+++ b/.gitconfig
@@ -14,6 +14,8 @@
 	prompt = false
 [pull]
 	ff = only
-[credential]
+[credential "https://git-codecommit.*.amazonaws.com"]
 	helper = !aws codecommit credential-helper $@
 	UseHttpPath = true
+[credential "https://github.com"]
+	helper = !gh auth git-credential

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,15 @@
 .DS_Store
 .git*
 !.github
+!.gitconfig
+!.gitignore
 .
 ..
 *.un~
 var/*
 *.swp
 .vim
+
+# .claude: ignore Claude Code state, allow only tracked overrides
+.claude/*
+!.claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 DOTPATH    := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 CANDIDATES := $(wildcard .??*)
-EXCLUSIONS := .DS_Store .git *.bck .*.swp
+EXCLUSIONS := .DS_Store .git *.bck .*.swp .claude
 DOTFILES   := $(filter-out $(EXCLUSIONS), $(CANDIDATES))
+# .claude is deployed file-by-file (not as a whole directory) because
+# ~/.claude is a live state directory managed by Claude Code itself
+# (projects/, history.jsonl, sessions/, ...). Only tracked items under
+# .claude/ are symlinked into ~/.claude/.
+CLAUDE_FILES := $(wildcard .claude/* .claude/.??*)
 
 setup: ## Setup environment settings
 	@DOTPATH=$(DOTPATH) /bin/bash $(DOTPATH)/setup.sh
@@ -18,6 +23,8 @@ deploy: ## Create symlink to home directory
 	@$(foreach val, $(DOTFILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)\
 	mkdir -p $(HOME)/.config/nvim; \
 	ln -fs $(DOTPATH)/.vimrc $(HOME)/.config/nvim/init.vim
+	@mkdir -p $(HOME)/.claude
+	@$(foreach val, $(CLAUDE_FILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
 
 
 clean: ## Remove the dot files


### PR DESCRIPTION
## What?
- `.bashrc` に `[[ -f $HOME/.bashrc.local ]] && source $HOME/.bashrc.local` を追加（`.zshrc` の既存挙動と対称）
- `.gitconfig` の credential helper を URL スコープに分離
  - `https://git-codecommit.*.amazonaws.com` → `!aws codecommit credential-helper $@`
  - `https://github.com` → `!gh auth git-credential`
- `Makefile`: `make deploy` で `.claude/` を個別ファイル単位で symlink するよう変更
  - `EXCLUSIONS` に `.claude` を追加し bulk deploy から除外
  - `CLAUDE_FILES := $(wildcard .claude/* .claude/.??*)` で配下を列挙し、`~/.claude/` 配下に個別 symlink
- `.gitignore`: `.claude/*` を ignore し、`!.claude/settings.local.json` をホワイトリスト
- `.claude/settings.local.json` を追跡対象に追加（`Bash(git fetch:*)` を許可）

## Why?
- マシン固有の env 行（例: `uv` の `$HOME/.local/bin/env`）を tracked dotfiles に混ぜず、`~/.bashrc.local` に退避できるようにする。`.zshrc` 側は既に同等の仕組みがあった
- `aws` CLI を入れていないマシンで GitHub への https push が `aws codecommit credential-helper` を呼び出して失敗していた。CodeCommit ヘルパーを host スコープに閉じ、GitHub は `gh` の認証を流用
- `~/.claude/` は Claude Code が `projects/`, `history.jsonl`, `sessions/`, `cache/` などを書き込む live state ディレクトリで、symlink で丸ごと置換できない。既存ディレクトリがある環境では `ln -sfnv` が `~/.claude/.claude` という入れ子 symlink を作って終わっていた
