### PR TITLE
feat: improve kp and add aws fzf utilities

### DIFF
--- a/bin/al
+++ b/bin/al
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# 必要なコマンドの存在確認
+command -v awslogs >/dev/null 2>&1 || {
+  echo "awslogs がインストールされていません。インストールしてください: pip install awslogs"
+  exit 1
+}
+command -v fzf >/dev/null 2>&1 || {
+  echo "fzf がインストールされていません。インストールしてください: brew install fzf（Mac）または適切な方法でインストールしてください。"
+  exit 1
+}
+
+# AWS プロファイル指定（必要に応じて変更）
+profile="default"
+region="ap-northeast-1"
+start=3d # デフォルトは 3 日前
+end=""   # デフォルトは現在
+LOG_OPTIONS="-wGS --timestamp"
+
+. $HOME/dotfiles/utils/parse_options.sh || exit 1
+
+# CloudWatch Logs のロググループをすべて取得
+echo "CloudWatch Logs のロググループを取得中..."
+LOG_GROUPS=$(awslogs groups --profile $profile --aws-region $region)
+
+# fzf を使ってロググループを選択
+SELECTED_LOG_GROUP=$(echo "$LOG_GROUPS" | fzf --prompt "ロググループを選択してください: " --height 40% --reverse)
+
+if [ -z "$SELECTED_LOG_GROUP" ]; then
+  echo "ロググループが選択されませんでした。終了します。"
+  exit 1
+fi
+
+echo "選択されたロググループ: $SELECTED_LOG_GROUP"
+
+# awslogs コマンドを組み立て
+AWSLOGS_CMD="awslogs get ${LOG_OPTIONS} \"$SELECTED_LOG_GROUP\" --profile \"$profile\" --aws-region \"$region\"  --start=\"$start\" --end=\"$end\" "
+
+echo "=== awslogs command ==="
+echo "$AWSLOGS_CMD"
+echo "========================"
+# awslogs コマンドを実行
+eval $AWSLOGS_CMD

--- a/bin/kp
+++ b/bin/kp
@@ -1,30 +1,79 @@
 #!/bin/bash
 
-PORT=$1
+set -u
 
-if [[ -z $PORT ]]; then
-  echo "Port number is required."
+ASSUME_YES=0
+PORTS=()
+
+for arg in "$@"; do
+  case "$arg" in
+  -y | --yes) ASSUME_YES=1 ;;
+  -h | --help)
+    echo "Usage: kp [-y|--yes] <port> [<port>...]"
+    exit 0
+    ;;
+  -*)
+    echo "Unknown option: $arg" >&2
+    exit 1
+    ;;
+  *) PORTS+=("$arg") ;;
+  esac
+done
+
+if [[ ${#PORTS[@]} -eq 0 ]]; then
+  echo "Port number is required." >&2
+  echo "Usage: kp [-y|--yes] <port> [<port>...]" >&2
   exit 1
 fi
 
-echo "Processes running on port $PORT:"
+kill_port() {
+  local port=$1
 
-lsof -i :$PORT
+  echo "Processes running on port $port:"
+  lsof -i :"$port"
 
-echo ""
-echo "Are you sure you want to kill the process on port $PORT? (y/n)"
-read answer
+  local pids
+  pids=$(lsof -ti :"$port")
 
-if [[ $answer != "y" ]]; then
-  echo "Process not killed."
-  exit 0
-fi
+  if [[ -z $pids ]]; then
+    echo "No process found on port $port."
+    return 0
+  fi
 
-PID=$(lsof -i :$PORT | awk '{print $2}' | sed -n '2p')
+  if [[ $ASSUME_YES -ne 1 ]]; then
+    echo ""
+    echo "Are you sure you want to kill the process(es) on port $port? (y/n)"
+    read -r answer
+    if [[ $answer != "y" ]]; then
+      echo "Process not killed."
+      return 0
+    fi
+  fi
 
-if [[ -n $PID ]]; then
-  kill -9 $PID
-  echo "Process on port $PORT killed."
-else
-  echo "No process found on port $PORT."
-fi
+  # SIGTERM first
+  echo "$pids" | xargs -r kill 2>/dev/null
+  sleep 1
+
+  # SIGKILL remaining
+  local remaining
+  remaining=$(lsof -ti :"$port")
+  if [[ -n $remaining ]]; then
+    echo "$remaining" | xargs -r kill -9 2>/dev/null
+  fi
+
+  # Verify
+  if [[ -z $(lsof -ti :"$port") ]]; then
+    echo "Process(es) on port $port killed."
+  else
+    echo "Failed to kill process(es) on port $port." >&2
+    return 1
+  fi
+}
+
+exit_code=0
+for port in "${PORTS[@]}"; do
+  kill_port "$port" || exit_code=1
+  echo ""
+done
+
+exit $exit_code

--- a/bin/lamin
+++ b/bin/lamin
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# 必要なコマンドの存在確認
+command -v aws >/dev/null 2>&1 || {
+  echo "aws CLI がインストールされていません。インストールしてください。"
+  exit 1
+}
+command -v fzf >/dev/null 2>&1 || {
+  echo "fzf がインストールされていません。インストールしてください。"
+  exit 1
+}
+
+# デフォルト値（parse_options.sh によって上書き可能）
+profile="default"
+region="ap-northeast-1"
+payload="{}"
+
+# コマンドライン引数を解析するために parse_options.sh をロード
+. $HOME/dotfiles/utils/parse_options.sh || exit 1
+
+# Lambda 関数の一覧を取得
+echo "Lambda 関数を取得中 (AWS プロファイル: $profile, リージョン: $region)..."
+LAMBDA_FUNCTIONS=$(aws lambda list-functions --profile "$profile" --region "$region" --query 'Functions[*].FunctionName' --output text)
+
+# fzf で Lambda 関数を選択
+SELECTED_FUNCTION=$(echo "$LAMBDA_FUNCTIONS" | tr '\t' '\n' | fzf --prompt "Lambda 関数を選択してください: " --height 40% --reverse)
+
+if [ -z "$SELECTED_FUNCTION" ]; then
+  echo "Lambda 関数が選択されませんでした。終了します。"
+  exit 1
+fi
+
+echo "選択された Lambda 関数: $SELECTED_FUNCTION"
+
+# Lambda 関数を呼び出す
+echo "Lambda 関数 $SELECTED_FUNCTION を呼び出します..."
+LAMBDA_INVOKE_COMMAND="aws lambda invoke --function-name \"$SELECTED_FUNCTION\" --payload \"$payload\" /dev/stdout --profile \"$profile\" --region \"$region\""
+
+echo "=== Lambda command ==="
+echo "$LAMBDA_INVOKE_COMMAND"
+echo "======================"
+
+eval $LAMBDA_INVOKE_COMMAND
+
+# 呼び出し結果を標準出力に表示
+echo "=== Lambda 呼び出し結果 ==="
+echo "$RESULT"

--- a/utils/parse_options.sh
+++ b/utils/parse_options.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright 2012  Johns Hopkins University (Author: Daniel Povey);
+#                 Arnab Ghoshal, Karel Vesely
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Parse command-line options.
+# To be sourced by another script (as in ". parse_options.sh").
+# Option format is: --option-name arg
+# and shell variable "option_name" gets set to value "arg."
+# The exception is --help, which takes no arguments, but prints the
+# $help_message variable (if defined).
+
+
+###
+### No we process the command line options
+###
+while true; do
+  [ -z "${1:-}" ] && break;  # break if there are no arguments
+  case "$1" in
+    # If the enclosing script is called with --help option, print the help
+    # message and exit.  Scripts should put help messages in $help_message
+  --help|-h) if [ -z "$help_message" ]; then echo "No help found." 1>&2;
+	  else printf "$help_message\n" 1>&2 ; fi;
+	  exit 0 ;;
+  --*=*) echo "$0: options to scripts must be of the form --name value, got '$1'"
+       exit 1 ;;
+    # If the first command-line argument begins with "--" (e.g. --foo-bar),
+    # then work out the variable name as $name, which will equal "foo_bar".
+  --*) name=`echo "$1" | sed s/^--// | sed s/-/_/g`;
+    # Next we test whether the variable in question is undefned-- if so it's
+    # an invalid option and we die.  Note: $0 evaluates to the name of the
+    # enclosing script.
+    # The test [ -z ${foo_bar+xxx} ] will return true if the variable foo_bar
+    # is undefined.  We then have to wrap this test inside "eval" because
+    # foo_bar is itself inside a variable ($name).
+      eval '[ -z "${'$name'+xxx}" ]' && echo "$0: invalid option $1" 1>&2 && exit 1;
+
+      oldval="`eval echo \\$$name`";
+    # Work out whether we seem to be expecting a Boolean argument.
+      if [ "$oldval" == "true" ] || [ "$oldval" == "false" ]; then
+	 was_bool=true;
+      else
+	 was_bool=false;
+      fi
+
+    # Set the variable to the right value-- the escaped quotes make it work if
+    # the option had spaces, like --cmd "queue.pl -sync y"
+      eval $name=\"$2\";
+
+    # Check that Boolean-valued arguments are really Boolean.
+      if $was_bool && [[ "$2" != "true" && "$2" != "false" ]]; then
+        echo "$0: expected \"true\" or \"false\": $1 $2" 1>&2
+        exit 1;
+      fi
+      shift 2;
+      ;;
+  *) break;
+  esac
+done
+
+
+# Check for an empty argument to the --cmd option, which can easily occur as a
+# result of scripting errors.
+[ ! -z "${cmd+xxx}" ] && [ -z "$cmd" ] && echo "$0: empty argument to --cmd option" 1>&2 && exit 1;
+
+
+true; # so this script returns exit code 0.


### PR DESCRIPTION
## What?
- `bin/kp`: 複数ポート対応、`-y`/`--yes` フラグ、SIGTERM→SIGKILL の二段階 kill、エラーハンドリング強化
- `bin/al`: `awslogs` + `fzf` で CloudWatch ロググループを選択→取得する新規ユーティリティ
- `bin/lamin`: `aws lambda` + `fzf` で関数選択→invoke する新規ユーティリティ
- `utils/parse_options.sh`: `bin/al` / `bin/lamin` の引数パーサ（Apache-2.0、Kaldi 由来）

## Why?
- `kp` は単一ポート / 対話式 / 即 SIGKILL のみで、複数ポートを連続で殺したいケースや非対話 (`-y`) で使いたいケースに不便だった
- AWS 環境で CloudWatch Logs / Lambda の対話的な選択操作を頻繁にやるため、fzf ベースのラッパーを共通化

## Test plan
- [ ] `kp 3000` の対話フローが従来通り動く
- [ ] `kp -y 3000 3001` で複数ポートを連続 kill できる
- [ ] `al` でロググループ選択 → `awslogs get` が走る
- [ ] `lamin` で Lambda 関数選択 → invoke が走る