### PR TITLE
feat: support macOS in setup via Brewfile

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,41 @@
+name: macos
+
+on:
+  pull_request:
+    paths:
+      - "Brewfile"
+      - "setup.sh"
+      - "etc/install.sh"
+      - "etc/macos.sh"
+      - ".github/workflows/macos.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "Brewfile"
+      - "setup.sh"
+      - "etc/install.sh"
+      - "etc/macos.sh"
+      - ".github/workflows/macos.yml"
+
+jobs:
+  ci-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bash syntax check
+        run: |
+          bash -n setup.sh
+          bash -n etc/install.sh
+          bash -n etc/macos.sh
+      - name: brew bundle parse
+        run: brew bundle list --all --file=Brewfile
+      - name: brew info per entry
+        run: |
+          set -e
+          while read -r formula; do
+            brew info --formula "$formula" >/dev/null
+          done < <(brew bundle list --formula --file=Brewfile)
+          while read -r cask; do
+            brew info --cask "$cask" >/dev/null
+          done < <(brew bundle list --cask --file=Brewfile)

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,28 @@
+# CLI fundamentals
+brew "git"
+brew "tmux"
+brew "zsh"
+brew "neovim"
+brew "make"
+brew "curl"
+brew "unzip"
+
+# CLI productivity
+brew "gh"
+brew "ghq"
+brew "jq"
+brew "tree"
+brew "n"
+brew "fzf"
+brew "bats-core"
+
+# GUI apps
+cask "google-chrome"
+cask "slack"
+cask "tailscale"
+cask "1password"
+cask "notion"
+cask "claude-code"
+
+# Fonts
+cask "font-source-code-pro"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ My dotfiles growing like bonsai trees.
 
 - Ubuntu 22.04+
 - CentOS Stream 9
+- macOS (Apple Silicon / Intel)
 
 ## Setup
 
@@ -19,15 +20,22 @@ git clone https://github.com/onose004/dotfiles ~/dotfiles
 
 ### 2. Run setup
 
-Root 権限が必要です。
+Linux は root 権限が必要、macOS は通常ユーザーで実行します（Homebrew が root 実行を拒否するため）。
 
 ```sh
+# Linux
 sudo bash ~/dotfiles/setup.sh
+
+# macOS
+bash ~/dotfiles/setup.sh
 ```
 
 以下が自動で行われます:
 
-- 基本ツール (git, tmux, zsh, neovim, make, curl) のインストール
+- 基本ツールのインストール
+  - Linux: `apt-get` / `dnf` で git, tmux, zsh, neovim, make, curl, unzip
+  - macOS: Homebrew をブートストラップし、`Brewfile` に従って CLI / cask アプリを一括インストール
+- macOS 限定: Finder の隠しファイル表示などの defaults 設定 (`etc/macos.sh`)
 - dotfiles のシンボリックリンク作成 (`make deploy`)
 - プラグイン等のインストール (`make install`)
 

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -50,7 +50,7 @@ install_essential() {
     rm -rf /tmp/bats-core
   fi
 
-  # fzf
+  # fzf — clone for shell integration scripts; binary install differs per OS.
   if [[ ! -d $HOME/.fzf ]]; then
     git clone --depth 1 https://github.com/junegunn/fzf.git "$HOME/.fzf"
   else
@@ -59,10 +59,13 @@ install_essential() {
     popd
   fi
   "$HOME/.fzf/install" --bin
-  install -m 755 "$HOME/.fzf/bin/fzf" /usr/local/bin/fzf
+  # On macOS the fzf binary comes from Brewfile; only Linux needs a system-wide copy.
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    install -m 755 "$HOME/.fzf/bin/fzf" /usr/local/bin/fzf
+  fi
 
-  # ghq
-  if ! command -v ghq &>/dev/null; then
+  # ghq — Linux only; on macOS it comes from Brewfile.
+  if ! command -v ghq &>/dev/null && [[ "$OSTYPE" != "darwin"* ]]; then
     ARCH=$(uname -m)
     case $ARCH in
     x86_64) ARCH=amd64 ;;
@@ -82,30 +85,26 @@ install_essential() {
 # Addons — skipped when ADDONS=false
 
 install_addons() {
-  # node (via n)
+  # node (via n) — on macOS, n is installed via Brewfile; just pin a stable node.
   if ! command -v node &>/dev/null; then
     if command -v apt-get &>/dev/null; then
       DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm
-    elif command -v dnf &>/dev/null; then
-      dnf install -y nodejs npm
-    fi
-    npm install -g n
-    n stable
-    if command -v apt-get &>/dev/null; then
+      npm install -g n
+      n stable
       DEBIAN_FRONTEND=noninteractive apt-get purge -y nodejs npm
     elif command -v dnf &>/dev/null; then
+      dnf install -y nodejs npm
+      npm install -g n
+      n stable
       dnf remove -y nodejs npm
+    elif command -v n &>/dev/null; then
+      n stable
     fi
   fi
 
   # md-to-pdf
   if ! command -v md-to-pdf &>/dev/null; then
     npm install -g md-to-pdf
-  fi
-
-  # macOS
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    : # TODO(ryosuke.onose.2@hdwlab.co.jp): add brew cask apps
   fi
 }
 

--- a/etc/macos.sh
+++ b/etc/macos.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
+# macOS-only system defaults. Idempotent; safe to re-run.
 
-[[ "$OSTYPE" == "darwin"* ]] && {
-  # settings
-  defaults write com.apple.finder AppleShowAllFiles TRUE
-  defaults write com.apple.finder CreateDesktop -boolean false
-}
+set -euo pipefail
+
+[[ "$OSTYPE" == "darwin"* ]] || exit 0
+
+# Finder
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write com.apple.finder CreateDesktop -bool false
+
+killall Finder 2>/dev/null || true

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Run as root: sudo bash setup.sh
+# Linux: sudo bash setup.sh
+# macOS: bash setup.sh   (do NOT sudo; Homebrew refuses to run as root)
 
 set -euo pipefail
 
@@ -12,27 +13,7 @@ __        __   _                          _
 "
 
 # ------------------------------------------------------------------------------
-# PACKAGE MANAGER
-
-if command -v apt-get &>/dev/null; then
-  pkg_update() { DEBIAN_FRONTEND=noninteractive apt-get update -y; }
-  pkg_install() { DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"; }
-elif command -v dnf &>/dev/null; then
-  pkg_update() { dnf install -y epel-release 2>/dev/null || true; }
-  pkg_install() { dnf install -y --allowerasing "$@"; }
-else
-  echo "Unsupported package manager" >&2
-  exit 1
-fi
-
-# ------------------------------------------------------------------------------
-# FUNDAMENTALS
-
-pkg_update
-pkg_install git tmux zsh neovim make curl unzip
-
-# ------------------------------------------------------------------------------
-# DOTFILES
+# DOTFILES ROOT
 
 ROOT="${DOTFILES_ROOT:-$HOME/dotfiles}"
 DOT_REPO="https://github.com/onose004/dotfiles"
@@ -44,6 +25,39 @@ if [[ -z "${DOTFILES_ROOT:-}" ]]; then
     git -C "$ROOT" pull
   fi
 fi
+
+# ------------------------------------------------------------------------------
+# PACKAGE INSTALL
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS: bootstrap Homebrew if missing, then defer to Brewfile.
+  if ! command -v brew &>/dev/null; then
+    NONINTERACTIVE=1 /bin/bash -c \
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
+  # Make brew available in this shell for the rest of setup (Apple Silicon path).
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+  brew update
+  brew bundle --file="$ROOT/Brewfile"
+  bash "$ROOT/etc/macos.sh"
+elif command -v apt-get &>/dev/null; then
+  DEBIAN_FRONTEND=noninteractive apt-get update -y
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    git tmux zsh neovim make curl unzip
+elif command -v dnf &>/dev/null; then
+  dnf install -y epel-release 2>/dev/null || true
+  dnf install -y --allowerasing git tmux zsh neovim make curl unzip
+else
+  echo "Unsupported platform" >&2
+  exit 1
+fi
+
+# ------------------------------------------------------------------------------
+# DEPLOY
 
 cd "$ROOT"
 make deploy


### PR DESCRIPTION
## What?
- `Brewfile` を新規追加
  - CLI: `git`, `tmux`, `zsh`, `neovim`, `make`, `curl`, `unzip`, `gh`, `ghq`, `jq`, `tree`, `n`, `fzf`, `bats-core`
  - Cask: `google-chrome`, `slack`, `tailscale`, `1password`, `notion`, `claude-code`, `font-source-code-pro`
- `setup.sh` に `OSTYPE=darwin*` 分岐を追加
  - Homebrew 未導入なら `install.sh` をブートストラップ
  - `brew shellenv` を eval して同セッション内で `brew` を使える状態に（Apple Silicon / Intel 両対応）
  - `brew bundle --file="$ROOT/Brewfile"` で一括インストール
  - 続けて `etc/macos.sh` を呼んで Finder 設定を適用
- `etc/install.sh` を OS 対応に拡張
  - `fzf`: macOS では `/usr/local/bin` への手動 install をスキップ（brew が prefix に置く）
  - `ghq`: macOS では Linux バイナリの download / install をスキップ
  - `n` / `node`: macOS では `n stable` だけ呼ぶ（`n` 本体は Brewfile）
  - `install_addons` 内の `# TODO: add brew cask apps` を削除（Brewfile に置換）
- `etc/macos.sh` を整理
  - `set -euo pipefail` 化
  - `-bool true` 形式に統一
  - `killall Finder` で defaults 変更を即時反映
- `README.md` の Environment と Setup 節に macOS の手順を追記

## Why?
- macOS 環境では `setup.sh` が `apt-get`/`dnf` のどちらも検出できず `Unsupported package manager` で即落ちしていた
- 過去（master 時代）には macOS 分岐があったが、CI を Linux 2 系に絞る整理の中で剥がされ、`etc/install.sh` には `# TODO: add brew cask apps` だけが残っていた
- Brewfile に集約すれば、必須 CLI / GUI / フォントを 1 ファイルで宣言でき、`brew bundle check` での差分検出や `brew bundle dump` での同期もできる
- Linux 側は従来の `apt-get`/`dnf` 経路をそのまま維持しているため CI への影響なし
