### PR TITLE
feat: track user-defined claude skills for cross-machine sync

### DIFF
--- a/.claude/skills/create-pr-default/SKILL.md
+++ b/.claude/skills/create-pr-default/SKILL.md
@@ -8,6 +8,7 @@ description: 現在のブランチから標準化されたプルリクエスト�
 現在のブランチから標準化されたプルリクエストを作成します。
 
 ## 実行内容
+
 1. **現在のブランチが feature ブランチであることを確認**（main/develop でないこと）
 2. **最新の origin 状態を取得**（`git fetch origin`）
 3. 現在のブランチを分析してベースブランチを自動決定
@@ -16,6 +17,7 @@ description: 現在のブランチから標準化されたプルリクエスト�
 6. **`--draft` フラグを付けて Draft PR として作成する**
 
 ## ベースブランチ自動決定ロジック
+
 - **feat/**, **feature/**: main にマージ（develop がある場合は develop）
 - **fix/**, **hotfix/**: main にマージ
 - **release/**: main にマージ
@@ -23,18 +25,22 @@ description: 現在のブランチから標準化されたプルリクエスト�
 - その他: main にマージ
 
 ## 自動生成される PR 内容
+
 ### タイトル
+
 - ファイル変更内容を分析して Conventional Commits 形式で生成
 - `git diff origin/[target]..HEAD` から機能追加・修正・削除を判定
 - 日本語で記載
 
 ### 説明
+
 - What? / Why? セクションで構成する
 - HTML コメント `<!-- -->` はエスケープせずそのまま含める
 - HEREDOC を使用する際はシングルクォートで囲む（`<<'EOF'`）
 - Co-Authored-By 署名は入れない
 
 ## 技術的な実装原則
+
 1. **必ず最初に `git fetch origin` を実行**
 2. **`git diff origin/[target]..HEAD` で差分を取得**（ローカルブランチ参照禁止）
 3. **コミット履歴でなくファイル差分をベースに説明生成**

--- a/.claude/skills/create-pr-default/SKILL.md
+++ b/.claude/skills/create-pr-default/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: create-pr-default
+description: 現在のブランチから標準化されたプルリクエストを作成する
+---
+
+# プルリクエスト作成
+
+現在のブランチから標準化されたプルリクエストを作成します。
+
+## 実行内容
+1. **現在のブランチが feature ブランチであることを確認**（main/develop でないこと）
+2. **最新の origin 状態を取得**（`git fetch origin`）
+3. 現在のブランチを分析してベースブランチを自動決定
+4. **origin/[target] との差分を分析**して PR タイトルを自動生成
+5. **実際のファイル変更を分析**して詳細な説明を生成
+6. **`--draft` フラグを付けて Draft PR として作成する**
+
+## ベースブランチ自動決定ロジック
+- **feat/**, **feature/**: main にマージ（develop がある場合は develop）
+- **fix/**, **hotfix/**: main にマージ
+- **release/**: main にマージ
+- **docs/**, **chore/**: main にマージ（develop がある場合は develop）
+- その他: main にマージ
+
+## 自動生成される PR 内容
+### タイトル
+- ファイル変更内容を分析して Conventional Commits 形式で生成
+- `git diff origin/[target]..HEAD` から機能追加・修正・削除を判定
+- 日本語で記載
+
+### 説明
+- What? / Why? セクションで構成する
+- HTML コメント `<!-- -->` はエスケープせずそのまま含める
+- HEREDOC を使用する際はシングルクォートで囲む（`<<'EOF'`）
+- Co-Authored-By 署名は入れない
+
+## 技術的な実装原則
+1. **必ず最初に `git fetch origin` を実行**
+2. **`git diff origin/[target]..HEAD` で差分を取得**（ローカルブランチ参照禁止）
+3. **コミット履歴でなくファイル差分をベースに説明生成**
+4. リモートブランチが存在しない場合は自動プッシュ（`git push -u origin HEAD`）
+5. **必ず `gh pr create --draft ...` で Draft PR として作成する**（通常 PR で作るのは禁止）

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ var/*
 # .claude: ignore Claude Code state, allow only tracked overrides
 .claude/*
 !.claude/settings.local.json
+!.claude/skills
+!.claude/skills/**

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ DOTFILES   := $(filter-out $(EXCLUSIONS), $(CANDIDATES))
 # ~/.claude is a live state directory managed by Claude Code itself
 # (projects/, history.jsonl, sessions/, ...). Only tracked items under
 # .claude/ are symlinked into ~/.claude/.
-CLAUDE_FILES := $(wildcard .claude/* .claude/.??*)
+# .claude/skills/ is descended into per-skill so that machine-local
+# skills can coexist alongside tracked ones in ~/.claude/skills/.
+CLAUDE_FILES  := $(filter-out .claude/skills, $(wildcard .claude/* .claude/.??*))
+CLAUDE_SKILLS := $(wildcard .claude/skills/*)
 
 setup: ## Setup environment settings
 	@DOTPATH=$(DOTPATH) /bin/bash $(DOTPATH)/setup.sh
@@ -23,8 +26,9 @@ deploy: ## Create symlink to home directory
 	@$(foreach val, $(DOTFILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)\
 	mkdir -p $(HOME)/.config/nvim; \
 	ln -fs $(DOTPATH)/.vimrc $(HOME)/.config/nvim/init.vim
-	@mkdir -p $(HOME)/.claude
+	@mkdir -p $(HOME)/.claude $(HOME)/.claude/skills
 	@$(foreach val, $(CLAUDE_FILES), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	@$(foreach val, $(CLAUDE_SKILLS), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
 
 
 clean: ## Remove the dot files


### PR DESCRIPTION
## What?
- `.claude/skills/create-pr-default/SKILL.md` を追跡対象に追加（既存のユーザースキル）
- `.gitignore`: `!.claude/skills` と `!.claude/skills/**` を追加し、`.claude/*` の除外から逃がす
- `Makefile`: `.claude/skills/` を per-skill で symlink するよう変更
  - `CLAUDE_FILES` から `.claude/skills` 自身を除外
  - `CLAUDE_SKILLS := $(wildcard .claude/skills/*)` で配下を列挙
  - `deploy` で `~/.claude/skills/<name>` ごとに個別 symlink

## Why?
- ユーザー定義の Claude skill を複数マシン間で同期したい。dotfiles リポを clone → `make deploy` で全マシンが同じ skill セットを参照する状態にする
- `.claude/skills/` をディレクトリ単位で symlink すると、移行時にマシン側がすでに同名ディレクトリを持っている場合に PR #15 で直したのと同じ nested symlink バグが再発する（`~/.claude/skills/skills -> repo/.claude/skills`）。per-skill 化することで、各 skill ディレクトリだけが symlink になり、`~/.claude/skills/` 自体は実ディレクトリのまま残せる
- per-skill symlink にすることで、マシン固有の skill（同期したくないもの）を `~/.claude/skills/` 直下に実体として並べて共存させられる余地も残る

## Migration (既存マシン)
他マシンで `make deploy` する前に、追跡対象になった skill と同名の実ディレクトリを `~/.claude/skills/` から消す必要があります:

```sh
rm -r ~/.claude/skills/create-pr-default   # 中身は本 PR で repo に取り込み済み
make deploy
```

## Test plan
- [x] このマシンで migration → `make deploy` を実行し、`~/.claude/skills/create-pr-default` が `<repo>/.claude/skills/create-pr-default` への symlink になることを確認
- [x] symlink 経由で SKILL.md が読めることを確認
- [x] `~/.claude/settings.local.json` のローカル設定が壊れないことを確認（既存挙動と同じ）
- [x] `make fmt` で差分が出ないことを確認